### PR TITLE
Fix for special character support when using Microsoft Translator API

### DIFF
--- a/Ulis.Net/Ulis.Net.Library/MicrosoftTranslatorClient.cs
+++ b/Ulis.Net/Ulis.Net.Library/MicrosoftTranslatorClient.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
+using System.Web;
 using System.Xml.Serialization;
 
 namespace Ulis.Net.Library
@@ -26,9 +27,11 @@ namespace Ulis.Net.Library
             {
                 client.DefaultRequestHeaders.TryAddWithoutValidation(SubscriptionKeyHeader, _subscriptionKey);
 
+                var escapedText = HttpUtility.UrlEncode(text);
+
                 var uri = new UriBuilder(MicrosoftTranslatorApiUrlBase)
                 {
-                    Query = $"text={text}&to={TargetLanguage}"
+                    Query = $"text={escapedText}&to={TargetLanguage}"
                 }.Uri;
 
                 var translatedXml = await client.GetStringAsync(uri);


### PR DESCRIPTION
When translating text like "I wish to learn C#" or anything with a special character, these characters should be UrlEncoded since the Microsoft Translator API is called through an HttpClient using url parameters.